### PR TITLE
(refactor) fix indentation of DOCTYPE in index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,4 +1,4 @@
-    <!DOCTYPE html>
+<!DOCTYPE html>
 <html lang="en">
 <head>
     <meta charset="UTF-8">


### PR DESCRIPTION
## What this?

This is a super small, super basic PR.

All it does is remove some unneeded indentation at the top of `index.html`. It has no *real* effect on how the page works.

## Notes

It targets `master` (as is the norm)
